### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 `PreciseISO8601DateFormatter` is intended to be a drop-in replacement for `DateFormatter` or `ISO8601DateFormatter`. It's a subclass of [Formatter](https://developer.apple.com/documentation/foundation/formatter). Like Apple's built-in date formatters, `PreciseISO8601DateFormatter` is thread-safe.
 
+It's important to note, if you supply the formatter with a date with nanosecond precision, encode it into a string, and then decode that string back into a date, the original date and the decoded date will be different. The decoded date will have lost its nanosecond precision _(i.e., the date's nanosecond component would go from 448814988 to 448814000)_. This means, if you use `PreciseISO8601DateFormatter` to decode the date-time strings returned by your server, you should also use this formatter to store the encoded date-time strings locally.
+
 ## Usage
 
 ```swift
@@ -20,7 +22,7 @@ To use PreciseISO8601DateFormatter with the Swift Package Manager, add a depende
 ```swift
 let package = Package(
   dependencies: [
-    .package(url: "https://github.com/shareup/precise-iso-8601-date-formatter.git", from: "1.0.0")
+    .package(url: "https://github.com/shareup/precise-iso-8601-date-formatter.git", from: "1.0.1")
   ]
 )
 ```

--- a/Sources/PreciseISO8601DateFormatter/PreciseISO8601DateFormatter.swift
+++ b/Sources/PreciseISO8601DateFormatter/PreciseISO8601DateFormatter.swift
@@ -3,10 +3,13 @@ import Synchronized
 
 public final class PreciseISO8601DateFormatter: Formatter, @unchecked
 Sendable {
-    private let deps: Locked<Dependencies>
+    private let calendar: Locked<Calendar>
 
     override public init() {
-        deps = Locked(Dependencies())
+        var calendar = Calendar(identifier: .iso8601)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        calendar.locale = Locale(identifier: "en_US_POSIX")
+        self.calendar = Locked(calendar)
         super.init()
     }
 
@@ -37,24 +40,21 @@ Sendable {
 
 public extension PreciseISO8601DateFormatter {
     func string(from date: Date) -> String {
-        deps.access { deps in
-            let components = deps.calendar.dateComponents(
-                iso8601Components,
-                from: date
-            )
-
-            return String(
-                format: "%04d-%02d-%02dT%02d:%02d:%02d.%06dZ",
-                locale: deps.locale,
-                components.year!,
-                components.month!,
-                components.day!,
-                components.hour!,
-                components.minute!,
-                components.second!,
-                components.nanosecond! / nsecPerUsec
-            )
+        let components = calendar.access { calendar in
+            calendar.dateComponents(iso8601Components, from: date)
         }
+
+        return String(
+            format: "%04d-%02d-%02dT%02d:%02d:%02d.%06dZ",
+            locale: nil,
+            components.year!,
+            components.month!,
+            components.day!,
+            components.hour!,
+            components.minute!,
+            components.second!,
+            components.nanosecond! / nsecPerUsec
+        )
     }
 
     func date(from string: String) -> Date? {
@@ -107,7 +107,7 @@ public extension PreciseISO8601DateFormatter {
             components.nanosecond = nsecPerUsec * (try value(at: 20 ..< 26))
             try assertValue(at: 26, equals: "Z")
 
-            return deps.access { $0.calendar.date(from: components) }
+            return calendar.access { $0.date(from: components) }
         } catch {
             return nil
         }
@@ -115,19 +115,6 @@ public extension PreciseISO8601DateFormatter {
 }
 
 private struct ParseError: Error {}
-
-private struct Dependencies {
-    let calendar: Calendar
-    let locale: Locale
-
-    init() {
-        locale = Locale(identifier: "en_US_POSIX")
-        var calendar = Calendar(identifier: .iso8601)
-        calendar.timeZone = TimeZone(identifier: "UTC")!
-        calendar.locale = locale
-        self.calendar = calendar
-    }
-}
 
 private let nsecPerUsec = Int(NSEC_PER_USEC)
 

--- a/Sources/PreciseISO8601DateFormatter/PreciseISO8601DateFormatter.swift
+++ b/Sources/PreciseISO8601DateFormatter/PreciseISO8601DateFormatter.swift
@@ -44,6 +44,12 @@ public extension PreciseISO8601DateFormatter {
             calendar.dateComponents(iso8601Components, from: date)
         }
 
+        let (quotient, remainder) = components
+            .nanosecond!
+            .quotientAndRemainder(dividingBy: nsecPerUsec)
+
+        let microsecond = quotient + (remainder >= 500 ? 1 : 0)
+
         return String(
             format: "%04d-%02d-%02dT%02d:%02d:%02d.%06dZ",
             locale: nil,
@@ -53,7 +59,7 @@ public extension PreciseISO8601DateFormatter {
             components.hour!,
             components.minute!,
             components.second!,
-            components.nanosecond! / nsecPerUsec
+            microsecond
         )
     }
 

--- a/Tests/PreciseISO8601DateFormatterTests/PreciseISO8601DateFormatterTests.swift
+++ b/Tests/PreciseISO8601DateFormatterTests/PreciseISO8601DateFormatterTests.swift
@@ -57,6 +57,19 @@ final class PreciseISO8601DateFormatterTests: XCTestCase {
         XCTAssertNil(formatter.date(from: "2021-02-03T12:48:00.00012ZZ"))
     }
 
+    func testEncodedAndDecodedDatesEqualOriginal() throws {
+        let formatter = PreciseISO8601DateFormatter()
+
+        let original = Date()
+
+        let encoded1 = formatter.string(from: original)
+        let decoded = try XCTUnwrap(formatter.date(from: encoded1))
+        let encoded2 = formatter.string(from: decoded)
+
+        XCTAssertEqual(original, decoded)
+        XCTAssertEqual(encoded1, encoded2)
+    }
+
     func testThreadSafety() {
         let formatter = PreciseISO8601DateFormatter()
 
@@ -149,7 +162,6 @@ final class PreciseISO8601DateFormatterTests: XCTestCase {
         XCTAssertNil(output.pointee)
     }
 
-    // 0.646 sec
     func testPerformanceOfISO8601DateFormatter() {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withFractionalSeconds, .withInternetDateTime]
@@ -165,7 +177,6 @@ final class PreciseISO8601DateFormatterTests: XCTestCase {
         }
     }
 
-    // 0.284 sec
     func testPerformanceOfPreciseISO8601DateFormatter() {
         let formatter = PreciseISO8601DateFormatter()
 

--- a/Tests/PreciseISO8601DateFormatterTests/PreciseISO8601DateFormatterTests.swift
+++ b/Tests/PreciseISO8601DateFormatterTests/PreciseISO8601DateFormatterTests.swift
@@ -57,17 +57,20 @@ final class PreciseISO8601DateFormatterTests: XCTestCase {
         XCTAssertNil(formatter.date(from: "2021-02-03T12:48:00.00012ZZ"))
     }
 
-    func testEncodedAndDecodedDatesEqualOriginal() throws {
+    func testRoundtrippingAlwaysResultsInIdenticalDates() throws {
         let formatter = PreciseISO8601DateFormatter()
 
-        let original = Date()
+        let encoded1 = formatter.string(from: Date())
+        let decoded1 = try XCTUnwrap(formatter.date(from: encoded1))
+        let encoded2 = formatter.string(from: decoded1)
+        let decoded2 = try XCTUnwrap(formatter.date(from: encoded2))
+        let encoded3 = formatter.string(from: decoded2)
+        let decoded3 = try XCTUnwrap(formatter.date(from: encoded3))
 
-        let encoded1 = formatter.string(from: original)
-        let decoded = try XCTUnwrap(formatter.date(from: encoded1))
-        let encoded2 = formatter.string(from: decoded)
-
-        XCTAssertEqual(original, decoded)
         XCTAssertEqual(encoded1, encoded2)
+        XCTAssertEqual(decoded1, decoded2)
+        XCTAssertEqual(encoded1, encoded3)
+        XCTAssertEqual(decoded1, decoded3)
     }
 
     func testThreadSafety() {


### PR DESCRIPTION
- [x] Add performance tests
- [x] Remove locale from string formatter
- [x] Round to nearest microsecond when truncating nanoseconds

After setting locale to nil in `String(format:locale:_:)`, the performance of `PreciseISO8601DateFormatter` went from 4x slower than `ISO8601DateFormatter` to more than 2x faster.

I ran the tests with Arabic/Saudia Arabia, Hebrew/Israel, and Vietnamese/Vietnam locale settings, and everything continued to work.

`Date`'s internal representation is a `Double`, representing the number of seconds since January 1, 2001 _(the "reference date")_. As a result, encoding the date and then decoding it back into a date is a slightly lossy operation. The least significant nanoseconds digits will often be different. To account for those differences, we round to the nearest microsecond when truncating nanoseconds during encoding.